### PR TITLE
Commit reference message

### DIFF
--- a/lib/t1k.rb
+++ b/lib/t1k.rb
@@ -68,7 +68,7 @@ module T1k
     Repository.instance_eval do
       @@adapter =  self.default_repository
       class << self
-        delegate :create_issue, :get_issue, :get_issue_number, to: @@adapter
+        delegate :ref_message, :create_issue, :get_issue, :get_issue_number, to: @@adapter
       end
     end
   end

--- a/lib/t1k/commands/commit.rb
+++ b/lib/t1k/commands/commit.rb
@@ -3,13 +3,14 @@ module T1k
     class Commit
 
       def self.run(message, close, add, no_message)
+        T1k.setup_credentials
         message ||= ""
         text_close = ''
 
         raise "Message can't be blank. Use --no-message to ignore this rule." if message.empty? && !no_message
         branch = T1k::Commands::Branch.actual_branch.gsub("CARD","")
 
-        text_close = close ? 'close' : 'ref'
+        text_close = close ? 'close' : T1k::Repository.ref_message
 
         text_add = add ? 'a' : ''
 

--- a/lib/t1k/repositories/bitbucket.rb
+++ b/lib/t1k/repositories/bitbucket.rb
@@ -15,6 +15,9 @@ module T1k
       cattr_accessor :repo
       @@repo = ""
 
+      cattr_accessor :ref_message
+      @@ref_message = "ref"
+
       cattr_accessor :repo_owner
       @@repo_owner = ""
 
@@ -44,7 +47,7 @@ module T1k
           config.oauth_token = self.oauth_token
           config.oauth_secret = self.oauth_secret
         end
-        
+
         Tinybucket.new
       end
 

--- a/lib/t1k/repositories/github.rb
+++ b/lib/t1k/repositories/github.rb
@@ -13,6 +13,9 @@ module T1k
       cattr_accessor :repo
       @@repo = ""
 
+      cattr_accessor :ref_message
+      @@ref_message = ""
+
       cattr_accessor :messages
       @@messages = []
       cattr_accessor :errors

--- a/lib/t1k/version.rb
+++ b/lib/t1k/version.rb
@@ -1,3 +1,3 @@
 module T1k
-  VERSION = "4.2.2"
+  VERSION = "4.2.3"
 end

--- a/spec/t1k/commands/commit_spec.rb
+++ b/spec/t1k/commands/commit_spec.rb
@@ -7,33 +7,76 @@ describe T1k::Commands::Commit do
     let (:add)        { false   }
     let (:no_message) { true    }
 
-    it "should raise an exception" do
-      message    = ""
-      no_message =  false
+    context 'for github adapter' do
+      before do
+        T1k.setup do |config|
+          config.repository.adapter = :github
+        end
+      end
 
-      expect { T1k::Commands::Commit.run( message, close, add, no_message) }.to raise_error("Message can't be blank. Use --no-message to ignore this rule.")
+      it "should raise an exception" do
+        message    = ""
+        no_message =  false
+
+        expect { T1k::Commands::Commit.run( message, close, add, no_message) }.to raise_error("Message can't be blank. Use --no-message to ignore this rule.")
+      end
+
+      it "does not raise an exception" do
+        message    = ""
+        no_message =  true
+
+        expect { T1k::Commands::Commit.run( message, close, add, no_message) }.to_not raise_error
+      end
+
+      it "it have to skip circle ci when is not a close commit" do
+        close = false
+        expect_any_instance_of(Kernel).to receive(:system).with("git commit -m '[#branch_name] teste'")
+
+        T1k::Commands::Commit.run( msg, close, add, no_message)
+      end
+
+      it "have to close the issue when close=true is passed" do
+        close = true
+        expect_any_instance_of(Kernel).to receive(:system).with("git commit -m '[close#branch_name] teste'")
+
+        T1k::Commands::Commit.run( msg, close, add, no_message)
+      end
     end
 
+    context 'for bitbucket adapter' do
+      before do
+        T1k.setup do |config|
+          config.repository.adapter = :bitbucket
+        end
+      end
 
-    it "does not raise an exception" do
-      message    = ""
-      no_message =  true
+      it "should raise an exception" do
+        message    = ""
+        no_message =  false
 
-      expect { T1k::Commands::Commit.run( message, close, add, no_message) }.to_not raise_error("Message can't be blank. Use --no-message to ignore this rule.")
-    end
+        expect { T1k::Commands::Commit.run( message, close, add, no_message) }.to raise_error("Message can't be blank. Use --no-message to ignore this rule.")
+      end
 
-    it "it have to skip circle ci when is not a close commit" do
-      close = false
-      expect_any_instance_of(Kernel).to receive(:system).with("git commit -m '[ref#branch_name] teste'")
+      it "does not raise an exception" do
+        message    = ""
+        no_message =  true
 
-      T1k::Commands::Commit.run( msg, close, add, no_message)
-    end
+        expect { T1k::Commands::Commit.run( message, close, add, no_message) }.to_not raise_error
+      end
 
-    it "have to close the issue when close=true is passed" do
-      close = true
-      expect_any_instance_of(Kernel).to receive(:system).with("git commit -m '[close#branch_name] teste'")
+      it "it have to skip circle ci when is not a close commit" do
+        close = false
+        expect_any_instance_of(Kernel).to receive(:system).with("git commit -m '[ref#branch_name] teste'")
 
-      T1k::Commands::Commit.run( msg, close, add, no_message)
+        T1k::Commands::Commit.run( msg, close, add, no_message)
+      end
+
+      it "have to close the issue when close=true is passed" do
+        close = true
+        expect_any_instance_of(Kernel).to receive(:system).with("git commit -m '[close#branch_name] teste'")
+
+        T1k::Commands::Commit.run( msg, close, add, no_message)
+      end
     end
   end
 

--- a/spec/t1k/commands/pull_request_spec.rb
+++ b/spec/t1k/commands/pull_request_spec.rb
@@ -21,8 +21,7 @@ describe T1k::Commands::PullRequest do
           "git checkout master",
           "git pull --rebase origin master",
           "git checkout branch_name",
-          "git pull --rebase origin branch_name",
-          "git rebase master"
+          "git merge master"
         ].each do |cmd|
           allow_any_instance_of(Kernel).to receive(:system).with( cmd )
          end


### PR DESCRIPTION
Creates specific reference message for each possible repository adapter.

As **github** doesn't recognizes commit messages with `ref#issue_name` but **bitbucket** does, there's the need for each adapter to have it's reference message.